### PR TITLE
Only show open dialog on main window show even if no images are loaded

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -238,7 +238,9 @@ void MainWindow::about() {
 
 
 void MainWindow::showEvent(QShowEvent * event) {
-    loadImages();
+    if (io.getImageStack().size() == 0) {
+        loadImages();
+    }
 }
 
 


### PR DESCRIPTION
Only show the open dialog in the main window show event if no images are loaded (i.e. if the image stack is empty).  This prevents the open dialog from appearing unexpectedly when the window show event fires, i.e. on un-minimize or desktop switch.  