### PR TITLE
Windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.orig
 *.swp
+*.project
 *~
 .directory
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,8 +248,12 @@ if(WIN32)
     # Create the installer with makensis
     find_program(MAKENSIS_EXECUTABLE makensis.exe PATH_SUFFIXES "NSIS/Bin")
     if(MAKENSIS_EXECUTABLE)
-        message(STATUS "NSIS found!")
+        message(STATUS "NSIS found")
         set(SETUP_PROG hdrmerge-setup${WIN_ARCH}-${HDRMERGE_VERSION}.exe)
+        #file(TO_NATIVE_PATH "${PROJECT_SOURCE_DIR}" PROJ_SRC_DIR)   This doesn't work :(
+        string(REPLACE "/" "\\" PROJ_SRC_DIR "${PROJECT_SOURCE_DIR}")
+        message(STATUS "PROJECT_SOURCE_DIR = ${PROJECT_SOURCE_DIR}")
+        message(STATUS "PROJ_SRC_DIR       = ${PROJ_SRC_DIR}")
         configure_file(
             "${PROJECT_SOURCE_DIR}/data/setup.nsi"
             "${PROJECT_BINARY_DIR}/setup.nsi" @ONLY
@@ -261,7 +265,7 @@ if(WIN32)
             WORKING_DIRECTORY "${PROJECT_BINARY_DIR}")
         add_custom_target(hdrmerge-setup ALL DEPENDS "${PROJECT_BINARY_DIR}/${SETUP_PROG}")
     else()
-        message(STATUS "NSIS not found!")
+        message(STATUS "NSIS not found")
     endif()
 elseif(APPLE)
     set_source_files_properties(images/icon.icns PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")

--- a/data/setup.nsi
+++ b/data/setup.nsi
@@ -30,9 +30,9 @@ VIAddVersionKey "FileDescription" "${APPNAME}"
 VIAddVersionKey "FileVersion" "@HDRMERGE_VERSION@"
 VIAddVersionKey "ProductVersion" "@HDRMERGE_VERSION@"
 
-!define MUI_ICON "@PROJECT_SOURCE_DIR@/images/icon.ico"
+!define MUI_ICON "@PROJ_SRC_DIR@\images\icon.ico"
 !define MUI_HEADERIMAGE
-!define MUI_HEADERIMAGE_BITMAP "@PROJECT_SOURCE_DIR@/images/logo.bmp"
+!define MUI_HEADERIMAGE_BITMAP "@PROJ_SRC_DIR@\images\logo.bmp"
 !define MUI_HEADERIMAGE_RIGHT
 
 ;--------------------------------
@@ -40,7 +40,7 @@ VIAddVersionKey "ProductVersion" "@HDRMERGE_VERSION@"
 ; Pages
 
 !insertmacro MUI_PAGE_WELCOME
-!insertmacro MUI_PAGE_LICENSE "@PROJECT_SOURCE_DIR@/LICENSE"
+!insertmacro MUI_PAGE_LICENSE "@PROJ_SRC_DIR@\LICENSE"
 !insertmacro MUI_PAGE_COMPONENTS
 !insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
@@ -65,9 +65,9 @@ Section "HDRMerge (required)"
 
     ; Put file there
     File "hdrmerge.exe" \
-        "@PROJECT_SOURCE_DIR@/LICENSE" \
-        "@PROJECT_SOURCE_DIR@/LICENSE_icons" \
-        "@PROJECT_SOURCE_DIR@/README.md"
+        "@PROJ_SRC_DIR@\LICENSE" \
+        "@PROJ_SRC_DIR@\LICENSE_icons" \
+        "@PROJ_SRC_DIR@\README.md"
     File /oname=hdrmerge.com "hdrmerge-nogui.exe"
 
     ; Write the installation path into the registry


### PR DESCRIPTION
This branch is aimed at building HDRMerge on Windows. It should work already fine, however the linking process doesn't statically link libexiv2, which is a problem for the Setup process.