### PR TITLE
Fixing the paning method

### DIFF
--- a/src/DraggableScrollArea.cpp
+++ b/src/DraggableScrollArea.cpp
@@ -58,11 +58,9 @@ void DraggableScrollArea::mouseReleaseEvent(QMouseEvent * event) {
 void DraggableScrollArea::mouseMoveEvent(QMouseEvent * event) {
     if (moveViewport && (event->buttons() & Qt::LeftButton)) {
         QPoint delta = QCursor::pos() - mousePos;
-        //if (event->modifiers() & Qt::ControlModifier) {
-        // x3 panning speed
-        delta.setX(delta.x() * 3);
-        delta.setY(delta.y() * 3);
-        //}
+        // x5 panning speed
+        delta.setX(delta.x() * 5);
+        delta.setY(delta.y() * 5);
         horizontalScrollBar()->setValue(horizontalScrollBar()->value() - delta.x());
         verticalScrollBar()->setValue(verticalScrollBar()->value() - delta.y());
         mousePos = QCursor::pos();

--- a/src/DraggableScrollArea.cpp
+++ b/src/DraggableScrollArea.cpp
@@ -43,7 +43,7 @@ void DraggableScrollArea::toggleMoveViewport(bool toggle) {
 void DraggableScrollArea::mousePressEvent(QMouseEvent * event) {
     if (moveViewport && event->button() == Qt::LeftButton) {
         mousePos = QCursor::pos();
-        widget()->setCursor(QCursor(Qt::BlankCursor));
+        widget()->setCursor(QCursor(Qt::OpenHandCursor));
     }
 }
 
@@ -56,11 +56,16 @@ void DraggableScrollArea::mouseReleaseEvent(QMouseEvent * event) {
 
 
 void DraggableScrollArea::mouseMoveEvent(QMouseEvent * event) {
-    if (moveViewport && event->buttons() & Qt::LeftButton) {
+    if (moveViewport && (event->buttons() & Qt::LeftButton)) {
         QPoint delta = QCursor::pos() - mousePos;
+        //if (event->modifiers() & Qt::ControlModifier) {
+        // x3 panning speed
+        delta.setX(delta.x() * 3);
+        delta.setY(delta.y() * 3);
+        //}
         horizontalScrollBar()->setValue(horizontalScrollBar()->value() - delta.x());
         verticalScrollBar()->setValue(verticalScrollBar()->value() - delta.y());
-        QCursor::setPos(mousePos);
+        mousePos = QCursor::pos();
     }
 }
 

--- a/src/PreviewWidget.cpp
+++ b/src/PreviewWidget.cpp
@@ -33,7 +33,8 @@ using namespace hdrmerge;
 
 
 PreviewWidget::PreviewWidget(ImageStack & s, QWidget * parent) : QWidget(parent), stack(s),
-width(0), height(0), flip(0), addPixels(false), rmPixels(false), layer(0), radius(5), expMult(1.0) {
+width(0), height(0), flip(0), addPixels(false), rmPixels(false), layer(0), radius(5),
+mouseX(0), mouseY(0), expMult(1.0), cancelRender(false) {
     float g = 1.0f / 2.2f;
     for (int i = 0; i < 65536; i++) {
         gamma[i] = (int)std::floor(65536.0f * std::pow(i / 65536.0f, g)) >> 8;
@@ -200,7 +201,7 @@ void PreviewWidget::mouseEvent(QMouseEvent * event, bool pressed) {
     rotate(rx, ry);
     if (rx >= 0 && rx < (int)stack.getWidth() && ry >= 0 && ry < (int)stack.getHeight())
         emit pixelUnderMouse(rx, ry);
-    if (event->buttons() & Qt::LeftButton && (addPixels || rmPixels)) {
+    if ((event->buttons() & Qt::LeftButton) && (addPixels || rmPixels)) {
         event->accept();
         if (pressed) {
             stack.getMask().startAction(addPixels, layer);

--- a/src/PreviewWidget.hpp
+++ b/src/PreviewWidget.hpp
@@ -25,7 +25,7 @@
 
 #include <memory>
 #include <list>
-#include <QWidget>
+#include <qwidget.h>
 #include <QPaintEvent>
 #include <QFuture>
 #include "ImageStack.hpp"


### PR DESCRIPTION
The new method display a hand cursor when paning, without replacing the
cursor at the button press location. I also added a x3 multiplication
factor for paning, to move through the entire image with less paning
iteration (easy to remove if you find this annoying).