### PR TITLE
clang: include <iostream> for std::cerr

### DIFF
--- a/src/ExifTransfer.cpp
+++ b/src/ExifTransfer.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <exiv2/exiv2.hpp>
+#include <iostream>
 #include "ExifTransfer.hpp"
 #include "Log.hpp"
 using namespace hdrmerge;


### PR DESCRIPTION
For compilation on clang-1001.0.46.4