### PR TITLE
cmake: Fix finding exiv2 0.27.1

### DIFF
--- a/cmake/FindExiv2.cmake
+++ b/cmake/FindExiv2.cmake
@@ -48,17 +48,24 @@ endif (EXIV2_LIBRARY)
 
 # Get the version number from exiv2/version.hpp and store it in the cache:
 if (EXIV2_INCLUDE_DIR AND NOT EXIV2_VERSION)
-  file(READ ${EXIV2_INCLUDE_DIR}/exiv2/version.hpp EXIV2_VERSION_CONTENT)
-  string(REGEX MATCH "#define EXIV2_MAJOR_VERSION +\\( *([0-9]+) *\\)"  _dummy "${EXIV2_VERSION_CONTENT}")
-  set(EXIV2_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    if (EXISTS ${EXIV2_INCLUDE_DIR}/exiv2/exv_conf.h)
+        set(EXIV_VERSION_HEADER ${EXIV2_INCLUDE_DIR}/exiv2/exv_conf.h)
+    else()
+        set(EXIV_VERSION_HEADER ${EXIV2_INCLUDE_DIR}/exiv2/version.hpp)
+    endif()
 
-  string(REGEX MATCH "#define EXIV2_MINOR_VERSION +\\( *([0-9]+) *\\)"  _dummy "${EXIV2_VERSION_CONTENT}")
-  set(EXIV2_VERSION_MINOR "${CMAKE_MATCH_1}")
+    file(READ ${EXIV_VERSION_HEADER} EXIV2_VERSION_CONTENT)
 
-  string(REGEX MATCH "#define EXIV2_PATCH_VERSION +\\( *([0-9]+) *\\)"  _dummy "${EXIV2_VERSION_CONTENT}")
-  set(EXIV2_VERSION_PATCH "${CMAKE_MATCH_1}")
+    string(REGEX MATCH "#define EXIV2_MAJOR_VERSION +\\( *([0-9]+) *\\)"  _dummy "${EXIV2_VERSION_CONTENT}")
+    set(EXIV2_VERSION_MAJOR "${CMAKE_MATCH_1}")
 
-  set(EXIV2_VERSION "${EXIV2_VERSION_MAJOR}.${EXIV2_VERSION_MINOR}.${EXIV2_VERSION_PATCH}")
+    string(REGEX MATCH "#define EXIV2_MINOR_VERSION +\\( *([0-9]+) *\\)"  _dummy "${EXIV2_VERSION_CONTENT}")
+    set(EXIV2_VERSION_MINOR "${CMAKE_MATCH_1}")
+
+    string(REGEX MATCH "#define EXIV2_PATCH_VERSION +\\( *([0-9]+) *\\)"  _dummy "${EXIV2_VERSION_CONTENT}")
+    set(EXIV2_VERSION_PATCH "${CMAKE_MATCH_1}")
+
+    set(EXIV2_VERSION "${EXIV2_VERSION_MAJOR}.${EXIV2_VERSION_MINOR}.${EXIV2_VERSION_PATCH}")
 endif (EXIV2_INCLUDE_DIR AND NOT EXIV2_VERSION)
 
 if (EXIV2_VERSION)


### PR DESCRIPTION
The project put the version information in a new file. This means we
need to check for the file first before we parse it.