### PR TITLE
Fix wrong format "JPEG" for writing the preview.

### DIFF
--- a/src/DngFloatWriter.cpp
+++ b/src/DngFloatWriter.cpp
@@ -333,7 +333,7 @@ void DngFloatWriter::renderPreviews() {
     if (previewWidth > 0) {
         QBuffer buffer(&jpegPreviewData);
         buffer.open(QIODevice::WriteOnly);
-        QImageWriter writer(&buffer, "JPEG");
+        QImageWriter writer(&buffer, "JPG");
         writer.setQuality(85);
         if (!writer.write(preview)) {
             cerr << "Error converting the preview to JPEG: " << writer.errorString() << endl;


### PR DESCRIPTION
"JPEG" was valid in Qt4 (alongside "JPG"):
https://doc.qt.io/archives/qt-4.8/qimagewriter.html#supportedImageFormats
But got dropped in Qt5:
https://doc.qt.io/qt-5/qimagewriter.html#supportedImageFormats

Fixes #192