### PR TITLE
Proposed tool: Convert images to dng format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,15 @@ set(CMAKE_AUTORCC ON)
 
 find_package(Qt5 5.6 REQUIRED Core Widgets)
 
+message(STATUS "QT_DEFINITIONS: ${QT_DEFINITIONS}")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC ")
+
+include_directories(/usr/include/x86_64-linux-gnu/qt5/QtCore)
+include_directories(/usr/include/x86_64-linux-gnu/qt5/QtGui)
+include_directories(/usr/include/x86_64-linux-gnu/qt5)
+
+
 #include(${QT_USE_FILE})
 add_definitions(${QT_DEFINITIONS})
 
@@ -274,7 +283,7 @@ else()
     )
 endif()
 
-target_link_libraries(hdrmerge ${STRIP} ${hdrmerge_libs} Qt5::Widgets)
+
 
 if(WIN32)
     # Compile a target without GUI, for the .com executable
@@ -354,3 +363,30 @@ if(Boost_FOUND)
     add_subdirectory(test)
 endif()
 
+add_executable(tiff2dng tiff2dng.cpp)
+
+find_package(OpenCV REQUIRED)
+
+include_directories(${OpenCV_INCLUDE_DIRS})
+
+find_package(ZLIB REQUIRED)
+
+include_directories(${ZLIB_INCLUDE_DIRS})
+
+add_library(hdrmerge_lib
+    ${hdrmerge_sources}
+    )
+
+target_link_libraries(hdrmerge_lib
+    ${hdrmerge_libs} Qt5::Widgets Qt5::Core
+    )
+
+target_link_libraries(tiff2dng
+    Qt5::Widgets
+    ${hdrmerge_libs}
+    ${OpenCV_LIBS}
+    hdrmerge_lib
+    ${ZLIB_LIBRARIES}
+    )
+
+target_link_libraries(hdrmerge ${STRIP} ${hdrmerge_libs} Qt5::Widgets)

--- a/src/CFAPattern.hpp
+++ b/src/CFAPattern.hpp
@@ -41,6 +41,13 @@ public:
         }
     }
 
+    void setPattern(uint32_t f) {
+        filters = f;
+        if (filters == 9) {
+            throw std::runtime_error("need fcol function for Fujifilm X-Trans sensor");
+        }
+    }
+
     bool operator==(const CFAPattern & r) const {
         return filters == r.filters;
     }

--- a/tiff2dng.cpp
+++ b/tiff2dng.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+
+#include "src/DngFloatWriter.hpp"
+#include "src/ImageIO.hpp"
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
+
+
+void convert(std::string filename) {
+    std::cout << "reading input file " << filename << std::endl;
+    cv::Mat_<uint16_t> im = cv::imread(filename, cv::IMREAD_UNCHANGED);
+    int const width = im.cols;
+    int const height = im.rows;
+    std::cout << "size: " << im.size() << std::endl;
+    hdrmerge::Array2D<float> arr(width, height);
+    std::cout << "hdrmerge::Array2D size: " << arr.size() << std::endl;
+    for (int yy = 0; yy < height; ++yy) {
+        for (int xx = 0; xx < width; ++xx) {
+            arr(xx, yy) = double(im(yy, xx));
+        }
+    }
+    cv::Mat preview;
+    cv::cvtColor(im, preview, cv::COLOR_BayerBG2BGR);
+    cv::imwrite(filename + "-preview.tif", preview);
+    hdrmerge::DngFloatWriter writer;
+    writer.setPreviewWidth(100); // This is important, otherwise
+    hdrmerge::RawParameters params;
+    params.height = params.rawHeight = height;
+    params.width = params.rawWidth = width;
+    params.fileName = filename.c_str();
+    params.isoSpeed = 100;
+    params.shutter = 100;
+    params.aperture = 2.8;
+    //params.FC.setPattern(2);
+
+    std::cout << "Writing result" << std::endl;
+    writer.write(std::move(arr), params, (filename + ".dng").c_str());
+    std::cout << "done." << std::endl;
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 2) {
+        std::cout << "Usage: " << argv[0] << " input files..." << std::endl;
+    }
+
+
+    for (int ii = 1; ii < argc; ++ii) {
+        convert(argv[ii]);
+    }
+}

--- a/tiff2dng.cpp
+++ b/tiff2dng.cpp
@@ -9,6 +9,10 @@
 void convert(std::string filename) {
     std::cout << "reading input file " << filename << std::endl;
     cv::Mat_<uint16_t> im = cv::imread(filename, cv::IMREAD_UNCHANGED);
+    double minval = 0;
+    double maxval = 0;
+    cv::minMaxIdx(im, &minval, &maxval);
+    im *= 65535.0/maxval;
     int const width = im.cols;
     int const height = im.rows;
     std::cout << "size: " << im.size() << std::endl;
@@ -21,17 +25,31 @@ void convert(std::string filename) {
     }
     cv::Mat preview;
     cv::cvtColor(im, preview, cv::COLOR_BayerBG2BGR);
-    cv::imwrite(filename + "-preview.tif", preview);
-    hdrmerge::DngFloatWriter writer;
-    writer.setPreviewWidth(100); // This is important, otherwise
-    hdrmerge::RawParameters params;
+    preview.convertTo(preview, CV_8UC3, 1.0/256);
+    cv::resize(preview, preview, cv::Size(), .5, .5);
+    //cv::imwrite(filename + "-preview.tif", preview);
+    cv::cvtColor(preview, preview, cv::COLOR_BGR2RGB);
+    hdrmerge::RawParameters params((filename + ".dng").c_str());
     params.height = params.rawHeight = height;
     params.width = params.rawWidth = width;
     params.fileName = filename.c_str();
     params.isoSpeed = 100;
-    params.shutter = 100;
+    params.shutter = .1;
     params.aperture = 2.8;
-    //params.FC.setPattern(2);
+    params.colors = 3;
+    params.black = 0;
+
+
+    //QImage q_preview = hdrmerge::ImageIO::renderPreview(arr, params, 1.0);
+    QImage q_preview = QImage(preview.data, preview.size().width, preview.size().height, QImage::Format_RGB888);
+    std::cout << "q_preview width / height: " << q_preview.width() << " / " << q_preview.height() << std::endl;
+    hdrmerge::DngFloatWriter writer;
+    writer.setBitsPerSample(16);
+    writer.setPreviewWidth(q_preview.width());
+    writer.setPreview(q_preview);
+
+
+    params.FC.setPattern(3031741620);
 
     std::cout << "Writing result" << std::endl;
     writer.write(std::move(arr), params, (filename + ".dng").c_str());
@@ -42,7 +60,6 @@ int main(int argc, char ** argv) {
     if (argc < 2) {
         std::cout << "Usage: " << argv[0] << " input files..." << std::endl;
     }
-
 
     for (int ii = 1; ii < argc; ++ii) {
         convert(argv[ii]);


### PR DESCRIPTION
I sometimes take images using industrial cameras which produce raw streams of pixel values. Previously I could convert them to tiff / png or similar but RawTherapee (my favorite RAW editor) wouldn't load them as raw files and I was stuck with bilinear interpolation for demosaicing.
I managed to find other people's posts about that same problem but all the answers were disappointing ("Why would you even want to do that?", "Seems easy, just write a converter.") so I was very happy to find open source code which includes a DNG writer. I hacked a converter from any image format OpenCV can read to DNG.

My question is:
Do you want to include such a tool into the hdrmerge package? I would be willing to polish it if neccessary.