### PR TITLE
Remove FillOrder tag

### DIFF
--- a/src/DngFloatWriter.cpp
+++ b/src/DngFloatWriter.cpp
@@ -54,7 +54,6 @@ enum {
     PHOTOINTERPRETATION = 262,
     SAMPLESPERPIXEL = 277,
     BITSPERSAMPLE = 258,
-    FILLORDER = 266,
     ACTIVEAREA = 50829,
     MASKEDAREAS = 50830,
     CROPORIGIN = 50719,
@@ -270,9 +269,6 @@ void DngFloatWriter::createRawIFD() {
     rawIFD.addEntry(WHITELEVEL, IFD::SHORT, params->max);
     rawIFD.addEntry(SAMPLESPERPIXEL, IFD::SHORT, 1);
     rawIFD.addEntry(BITSPERSAMPLE, IFD::SHORT, bps);
-    if (bps == 24) {
-        rawIFD.addEntry(FILLORDER, IFD::SHORT, 1);
-    }
     rawIFD.addEntry(PLANARCONFIG, IFD::SHORT, 1);
     rawIFD.addEntry(COMPRESSION, IFD::SHORT, TIFF_DEFLATE);
     rawIFD.addEntry(PREDICTOR, IFD::SHORT, TIFF_FP2XPREDICTOR);


### PR DESCRIPTION
Upon closer inspection of [TIFF technical Note 3](http://chriscox.org/TIFFTN3d1.pdf) which is the basis for floating point DNGs, it appears there is no difference whatsoever in treatment of 16b vs 24b vs 32b floats.

The spurious paragraph in the DNG spec saying 

"If BitsPerSample is not equal to 8 or 16 or 32, then the bits must be packed into bytes using the TIFF default FillOrder of 1 (big-endian)"

was there even before DNG 1.4 that introduced floating point (and IMHO should've been updated to include 24 bits), and the mentioned FillOrder tag is relevant only for **bit** packing order within a byte (not applicable at all in this case), and not **byte** endiannes.

HDRMerge is writing a compressed bytestream in the file anyway so the endiannes doesn't matter, but any confusion should be best avoided. Any assumption of big-endian for the float->fp24->float conversion is purely internal (defined by the predictor) and has nothing to do with how the bytes are actually stored in the TIFF/DNG file (a compressed bytestream looks the same for all floating point bit depths).