### PR TITLE
FindAlglib.cmake: additionally use ALGLIB_DIR as search path

### DIFF
--- a/cmake/FindAlglib.cmake
+++ b/cmake/FindAlglib.cmake
@@ -26,13 +26,23 @@ find_path (ALGLIB_INCLUDES
     statistics.h
     stdafx.h
     PATHS
+    ${ALGLIB_DIR}/include/alglib
+    $ENV{ALGLIB_DIR}/include/alglib
+    ${ALGLIB_DIR}/include/libalglib
+    $ENV{ALGLIB_DIR}/include/libalglib
+    ${ALGLIB_DIR}/include/alglib3
+    $ENV{ALGLIB_DIR}/include/alglib3
     /usr/include/alglib/
     /usr/include/libalglib/
     /usr/local/include/alglib3/
     /usr/local/include/libalglib/
     )
 
-find_library (ALGLIB_LIBRARIES NAMES alglib alglib3)
+find_library (ALGLIB_LIBRARIES NAMES alglib alglib3
+    PATHS
+    ${ALGLIB_DIR}/lib
+    $ENV{ALGLIB_DIR}/lib
+    )
 
 # handle the QUIETLY and REQUIRED arguments and set ALGLIB_FOUND to TRUE if
 # all listed variables are TRUE


### PR DESCRIPTION
Hi all,

I started creating a personal package of hdrmerge 0.5.0 for NixOS (see https://codeberg.org/mkroehnert/nix-flakes).

On NixOS, it is required to explicitly pass dependencies to package builders.
Therefore, I had to update FindAlglib.cmake to also respect the ALGLIB_DIR variable.
\<package\>_DIR variables are conventionally used to pass package locations to CMake find_package() scripts.

Let me know, if you find this addition useful or if you would require changes to the PR.