### PR TITLE
LibRaw 0.21 API change

### DIFF
--- a/src/ImageIO.cpp
+++ b/src/ImageIO.cpp
@@ -36,7 +36,11 @@ using namespace hdrmerge;
 Image ImageIO::loadRawImage(const QString& filename, RawParameters & rawParameters, int shot_select) {
     std::unique_ptr<LibRaw> rawProcessor(new LibRaw);
     auto & d = rawProcessor->imgdata;
+#if LIBRAW_VERSION >= LIBRAW_MAKE_VERSION(0, 21, 0)
+    d.rawparams.shot_select = shot_select;
+#else
     d.params.shot_select = shot_select;
+#endif
     if (rawProcessor->open_file(rawParameters.fileName.toLocal8Bit().constData()) == LIBRAW_SUCCESS) {
         libraw_decoder_info_t decoder_info;
         rawProcessor->get_decoder_info(&decoder_info);


### PR DESCRIPTION
According to [LibRaw's changelog](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls) the API/datastruct has changed:
> 2021-09-14  Alex Tutubalin <lexa@lexa.ru>
> * API/datastruct Changes:
>  - imgdata.params.shot_select moved to imgdata.rawparams.shot_select
>   (because this is decode-time option, not postprocessing option)

This change was now released as version 0.21 of LibRaw on Dec 26th 2022 and will break current HDRmerge master branch:

> hdrmerge/src/ImageIO.cpp:42:18: error: ‘struct libraw_output_params_t’ has no member named ‘shot_select’
   42 |         d.params.shot_select = shot_select;

I included a version check for LibRaw around the offending code (deems just one occurrence) and tested to compile successfully with LibRaw v0.20 and v0.21 on Arch Linux.