### PR TITLE
fix compilation by including cstdlib

### DIFF
--- a/src/TiffDirectory.hpp
+++ b/src/TiffDirectory.hpp
@@ -22,6 +22,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 
 #ifndef _TIFFDIRECTORY_HPP_
 #define _TIFFDIRECTORY_HPP_


### PR DESCRIPTION
Without the inclusion of <cstdlib> compilation breaks (atleast on Fedora 38)