### PR TITLE
Use UniquePtr instead of AutoPtr

### DIFF
--- a/src/ExifTransfer.cpp
+++ b/src/ExifTransfer.cpp
@@ -41,7 +41,7 @@ private:
     QString srcFile, dstFile;
     const uint8_t * data;
     size_t dataSize;
-    Exiv2::Image::AutoPtr src, dst;
+    Exiv2::Image::UniquePtr src, dst;
 
     void copyXMP();
     void copyIPTC();
@@ -58,7 +58,7 @@ void hdrmerge::Exif::transfer(const QString & srcFile, const QString & dstFile,
 
 void ExifTransfer::copyMetadata() {
     try {
-        dst = Exiv2::ImageFactory::open(BasicIo::AutoPtr(new MemIo(data, dataSize)));
+        dst = Exiv2::ImageFactory::open(BasicIo::UniquePtr(new MemIo(data, dataSize)));
         dst->readMetadata();
     } catch (Exiv2::Error & e) {
         std::cerr << "Exiv2 error: " << e.what() << std::endl;

--- a/src/RawParameters.cpp
+++ b/src/RawParameters.cpp
@@ -49,7 +49,7 @@ void RawParameters::loadCamXyzFromDng() {
                 cc[j][i] = i == j ? 1.0 : 0.0;
             }
         }
-        Exiv2::Image::AutoPtr src = Exiv2::ImageFactory::open(fileName.toLocal8Bit().constData());
+        Exiv2::Image::UniquePtr src = Exiv2::ImageFactory::open(fileName.toLocal8Bit().constData());
         src->readMetadata();
         const Exiv2::ExifData & srcExif = src->exifData();
 


### PR DESCRIPTION
This is required to build with exiv2 0.28+, which dropped `Exiv2::*::AutoPtr`. I simply replaced occurrences of that with `UniquePtr` and it seem to work OK. It may not be correct, but it got me running again. :)